### PR TITLE
feat: derive bigGenePred aggregateField from UCSC label fields

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -50,7 +50,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10
+          version: 11
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: 11
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -49,8 +47,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: 11
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -23,8 +23,19 @@ automatically and fails fast with a build hint if it's missing.
 ## Do everything
 
 ```bash
-./run.sh           # Full pipeline: build + upload + deploy (default)
-./run.sh --dry-run # Build only, no upload or deploy
+./run.sh                 # Full pipeline: build + upload + deploy (default, incremental)
+./run.sh --dry-run       # Build only, no upload or deploy
+./run.sh --upload-only    # Upload + deploy only, skip build (run after --dry-run)
+./run.sh --reprocess-all # Re-derive every config from cached downloads
+./run.sh --staging       # Build + deploy website to staging only (no S3 upload / git push)
+```
+
+Two env vars force work past the incremental gates (canonical description in
+`common.sh`; they compose):
+
+```bash
+REPROCESS=1 ./run.sh      # re-derive outputs from cached downloads (implied by --reprocess-all)
+FETCH_UPDATES=1 ./run.sh  # re-pull upstream NCBI GFFs in both pipelines
 ```
 
 ## Preparing GenArk hubs

--- a/agent-docs/SHELL_HARDENING_HANDOFF.md
+++ b/agent-docs/SHELL_HARDENING_HANDOFF.md
@@ -1,0 +1,76 @@
+# Handoff: run.sh / common.sh shell hardening
+
+## Where this stands
+
+An integrity review of the orchestration scripts (`run.sh`, both `make.sh`,
+the three `common.sh` layers) produced 7 ranked gaps. Items **1–4 are done**
+(commit `abc3ad93462` on branch `derive`, "harden run.sh deploy path"; docs
+updated in `DEVELOPERS.md`). Items **5–7 are deferred** and described below so
+the next agent can pick them up.
+
+## What shipped (items 1–4)
+
+1. **`run.sh` now uses `set -euo pipefail`** (was bare `set -e`), matching both
+   `make.sh`. Verified safe: every variable referenced in `run.sh` is assigned
+   before use, so `-u` surfaces nothing latent, and there are no unguarded
+   pipes for `pipefail` to trip on. `bash -n` clean.
+   - **Not yet exercised end-to-end.** Run one real `./run.sh --dry-run` on the
+     deploy box to confirm no `-u` path fires that a static read can't reach.
+
+2. **`--upload-only` + `--reprocess-all` is now rejected** instead of silently
+   ignoring the reprocess (upload-only skips the whole build phase).
+
+3. **The final deploy `git add .` is now a scoped allowlist** (`git add -A --`
+   of the pipeline-generated paths), so stray working-tree edits no longer ride
+   along to origin under the generic "Updates" commit. Allowlist:
+   `genark2jbrowse/{hubs,taxon_images,processedHubJson,speciesDescriptions}`,
+   `ucsc2jbrowse/{configs,configs-minimal,blockedFiles,removedTracks,blockedFiles.json,removedTracks.json,fileListing.txt}`,
+   `website/src/*.json`. (`hubs/` is committed separately earlier in the script.)
+   - Confirmed by test: an in-scope new file stages; strays at repo root and in
+     `agent-docs/` do not.
+   - **If you add a new generated output dir, add it to this allowlist** or it
+     silently stops being committed. This is the one maintenance cost of the
+     change vs. `git add .`.
+
+4. **`REPROCESS` / `FETCH_UPDATES` control plane documented canonically** in root
+   `common.sh` (the single file both pipelines source) and surfaced in
+   `run.sh --help` + `DEVELOPERS.md`. The model: `REPROCESS` re-derives from
+   cached downloads; `FETCH_UPDATES` re-pulls upstream NCBI GFFs; they are
+   independent and compose.
+
+## Deferred (items 5–7) — the real follow-up refactor
+
+5. **Inconsistent flag vocabulary across the three entry points.** `genark`
+   exposes `--all`; `ucsc` exposes `--skip-download`; `run.sh` exposes neither.
+   Two options: (a) quick — give `run.sh` a `--skip-download` passthrough and an
+   `--only genark|ucsc` selector; (b) real fix — factor a shared
+   `parse_common_flags` into root `common.sh` so all three accept the same core
+   flags with identical semantics.
+
+6. **Two near-duplicate `downloadNcbiGff.sh`** (genark + ucsc). Different
+   downloaders (`wget -N` vs `datasets download`) but now-identical re-download
+   gate (`FETCH_UPDATES` / file-existence). They will drift. Minimum: a
+   cross-reference comment; better: extract the gate decision into `common.sh`.
+
+7. **Error swallowing conflates outcomes.** `git commit … || echo "No changes"`
+   (run.sh lines ~153 and ~209) reports *any* commit failure as "nothing to
+   commit"; `parallel … || true` in the genark chain PIFs hides persistent
+   failures. Fix: check `git diff --cached --quiet` before committing so only the
+   genuine empty case is silenced.
+
+## Gotcha found along the way (worth its own fix)
+
+On the dev machine, `git add` **refuses to re-stage the two pre-existing
+modified `genark2jbrowse/speciesDescriptions/Dengue-virus-type-{3,4}.json`
+files** — even `git add .` / after `touch`. No `.gitattributes`, no clean
+filter, no gitignore match, no fsmonitor, `ls-files -v` shows normal `H`. It's a
+stale index-stat state on a large (~38 MB) index. `git diff` sees the change;
+`git add` no-ops. Consequence: those files aren't actually being committed today
+regardless of the `git add` scoping. A `git update-index --really-refresh` (or
+`git add --renormalize .`) should clear it. Not addressed in this commit.
+
+## Files touched
+
+- `run.sh` — items 1, 2, 3, 4 (help text)
+- `common.sh` — item 4 (control-plane doc block)
+- `DEVELOPERS.md` — "Do everything" section: flags + env vars

--- a/common.sh
+++ b/common.sh
@@ -5,6 +5,12 @@
 # Shared configuration for all scripts.
 # Source this file at the top of other scripts: source "$(dirname "$0")/../common.sh"
 #
+# Control plane (both pipelines, incremental by default). Two independent env
+# axes that compose:
+#   REPROCESS=1      re-derive outputs from cached downloads, ignoring the
+#                    change gates (implied by make.sh --reprocess-all).
+#   FETCH_UPDATES=1  re-pull upstream NCBI GFFs even if a local copy exists;
+#                    regeneration then cascades from the newer file.
 
 # Suppress Node.js experimental warnings
 export NODE_OPTIONS="--experimental-strip-types --no-warnings=ExperimentalWarning"

--- a/hubtools/src/createTrackConfiguration.test.ts
+++ b/hubtools/src/createTrackConfiguration.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { createTrackConfiguration } from './createTrackConfiguration.ts'
+
+import type { RaStanza, TrackDbFile } from '@gmod/ucsc-hub'
+
+const sequenceAdapter = { type: 'TwoBitAdapter', uri: 'seq.2bit' }
+const trackDbUrl = 'https://example.com/hub/hg38/trackDb.txt'
+
+function build(data: Record<string, string>) {
+  const track = { name: data.track, data } as unknown as RaStanza
+  const trackDb = { data: { [data.track!]: track } } as unknown as TrackDbFile
+  return createTrackConfiguration({
+    track,
+    trackName: data.track!,
+    trackDb,
+    trackDbUrl,
+    sequenceAdapter,
+    assemblyName: 'hg38',
+  })
+}
+
+describe('createTrackConfiguration aggregateField derivation', () => {
+  it('sets aggregateField from defaultLabelFields for bigGenePred', () => {
+    const conf = build({
+      track: 'ncbiRefSeq',
+      type: 'bigGenePred',
+      bigDataUrl: 'ncbiRefSeq.bb',
+      shortLabel: 'RefSeq All',
+      labelFields: 'name2,geneName,geneName2',
+      defaultLabelFields: 'name2',
+    })
+    assert.equal(conf?.adapter.aggregateField, 'name2')
+  })
+
+  it('falls back to first labelFields when no default', () => {
+    const conf = build({
+      track: 'ncbiRefSeq',
+      type: 'bigGenePred',
+      bigDataUrl: 'ncbiRefSeq.bb',
+      shortLabel: 'RefSeq All',
+      labelFields: 'geneName,geneName2',
+    })
+    assert.equal(conf?.adapter.aggregateField, 'geneName')
+  })
+
+  it('leaves aggregateField unset for non-bigGenePred big tracks', () => {
+    const conf = build({
+      track: 'someBigBed',
+      type: 'bigBed',
+      bigDataUrl: 'someBigBed.bb',
+      shortLabel: 'Some bigBed',
+      defaultLabelFields: 'name',
+    })
+    assert.equal(conf?.adapter.aggregateField, undefined)
+  })
+})

--- a/hubtools/src/createTrackConfiguration.ts
+++ b/hubtools/src/createTrackConfiguration.ts
@@ -1,4 +1,5 @@
 import { categoryMap } from './const.ts'
+import { firstField } from './featureDisplay.ts'
 import { createHtmlLink, extractParentTracks } from './trackUtils.ts'
 import { resolve } from './util.ts'
 
@@ -47,12 +48,20 @@ function makeAdapterConf(
     const trackName = data.track ?? ''
     const disableGeneHeuristic =
       trackName.endsWith('tandemDups') || trackName.endsWith('gapOverlap')
+    // bigGenePred groups transcripts into genes; UCSC's own defaultLabelFields
+    // (fallback labelFields) names the gene field to aggregate on, e.g. name2
+    // for ncbiRefSeq, rather than the adapter's fixed geneName2 default
+    const aggregateField =
+      baseTrackType === 'bigGenePred'
+        ? (firstField(data.defaultLabelFields) ?? firstField(data.labelFields))
+        : undefined
     return {
       type: 'FeatureTrack',
       adapter: {
         type: 'BigBedAdapter',
         uri,
         ...(disableGeneHeuristic ? { disableGeneHeuristic: true } : {}),
+        ...(aggregateField ? { aggregateField } : {}),
       },
     }
   } else if (baseTrackType === 'vcfTabix') {

--- a/hubtools/src/featureDisplay.ts
+++ b/hubtools/src/featureDisplay.ts
@@ -12,7 +12,7 @@ export interface FeatureDisplay {
   }[]
 }
 
-function firstField(value: unknown) {
+export function firstField(value: unknown) {
   return typeof value === 'string' ? value.split(',')[0]! : undefined
 }
 

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@
 #                           # same production S3 data via absolute URLs.
 #
 
-set -e
+set -euo pipefail
 export NODE_OPTIONS="--experimental-strip-types --no-warnings=ExperimentalWarning"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -59,6 +59,10 @@ for arg in "$@"; do
     echo "                   Skips S3 data upload and git commit/push; the"
     echo "                   staging site reads the same production S3 data."
     echo "  --help, -h       Show this help message"
+    echo ""
+    echo "Env vars (see common.sh):"
+    echo "  REPROCESS=1      Re-derive from cached downloads (implied by --reprocess-all)"
+    echo "  FETCH_UPDATES=1  Re-pull upstream NCBI GFFs in both pipelines"
     exit 0
     ;;
   *)
@@ -77,6 +81,12 @@ fi
 
 if [ "$STAGING" = true ] && [ "$DRY_RUN" = true ]; then
   echo "Error: --staging deploys the website, so it cannot be used with --dry-run"
+  exit 1
+fi
+
+# --upload-only skips the build, so --reprocess-all would silently do nothing.
+if [ "$UPLOAD_ONLY" = true ] && [ "$REPROCESS_ALL" = true ]; then
+  echo "Error: --upload-only skips the build, so it cannot be combined with --reprocess-all"
   exit 1
 fi
 
@@ -187,7 +197,15 @@ elif [ "$DRY_RUN" = false ]; then
   describe() { [ "$1" = 1 ] && echo "changed" || echo "unchanged"; }
   echo "=== RUN SUMMARY === genark data: $(describe "$GENARK_CHANGED") | ucsc data: $(describe "$UCSC_CHANGED") | website source: $(describe "$WEBSITE_DIRTY") | website deployed: $WEBSITE_DEPLOYED"
 
-  git add .
+  # Scope the commit to pipeline-generated paths so stray edits in the working
+  # tree don't ride along to origin. hubs/ was committed above.
+  git add -A -- \
+    genark2jbrowse/hubs genark2jbrowse/taxon_images \
+    genark2jbrowse/processedHubJson genark2jbrowse/speciesDescriptions \
+    ucsc2jbrowse/configs ucsc2jbrowse/configs-minimal \
+    ucsc2jbrowse/blockedFiles ucsc2jbrowse/removedTracks \
+    ucsc2jbrowse/blockedFiles.json ucsc2jbrowse/removedTracks.json \
+    ucsc2jbrowse/fileListing.txt website/src/*.json
   git commit -m "Updates" || echo "No additional changes to commit"
   git push
 

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,9 @@
 #                           # Incremental: only new/changed assemblies rebuilt.
 #   ./run.sh --dry-run      # Build only, no upload or deploy
 #   ./run.sh --upload-only  # Upload + deploy only, skip build (run after --dry-run)
-#   ./run.sh --reprocess-all # Re-download and reprocess everything from scratch
+#   ./run.sh --reprocess-all # Reprocess genark2jbrowse + ucsc2jbrowse from
+#                           # cached downloads (re-derives all configs; does not
+#                           # re-pull NCBI GFFs unless FETCH_UPDATES=1)
 #   ./run.sh --staging      # Build + deploy website to staging only. Skips S3
 #                           # data upload and git commit/push; staging reads the
 #                           # same production S3 data via absolute URLs.
@@ -49,8 +51,10 @@ for arg in "$@"; do
     echo "                   are reprocessed."
     echo "  --dry-run        Build only, no upload or deploy"
     echo "  --upload-only    Upload + deploy only, skip build (run after --dry-run)"
-    echo "  --reprocess-all  Re-download and reprocess every assembly from scratch."
-    echo "                   Use after changing converter code/templates."
+    echo "  --reprocess-all  Reprocess genark2jbrowse + ucsc2jbrowse from cached"
+    echo "                   downloads (re-derives every config). Use after changing"
+    echo "                   converter code/templates. Does not re-pull NCBI GFFs"
+    echo "                   unless FETCH_UPDATES=1."
     echo "  --staging        Build, then deploy the website to staging only."
     echo "                   Skips S3 data upload and git commit/push; the"
     echo "                   staging site reads the same production S3 data."

--- a/ucsc2jbrowse/downloadNcbiGff.sh
+++ b/ucsc2jbrowse/downloadNcbiGff.sh
@@ -17,6 +17,10 @@
 #   ./downloadNcbiGff.sh             # every db in ncbiRefSeqAccessions.tsv
 #   ./downloadNcbiGff.sh hg38 mm39   # only the named dbs
 #
+# By default we only fetch a GFF we don't already have, so a --reprocess-all
+# rebuild re-derives configs from cached GFFs without re-hitting NCBI (matching
+# genark2jbrowse). Set FETCH_UPDATES=1 to force a re-download of every GFF.
+#
 
 set -euo pipefail
 
@@ -45,7 +49,7 @@ process_db() {
   if [ ! -f "$config" ]; then
     log "Skipping $db: no config.json (assembly not built)"
   else
-    if [ ! -f "$gff.csi" ] || [ -n "${REPROCESS:-}" ]; then
+    if [ ! -f "$gff.csi" ] || [ -n "${FETCH_UPDATES:-}" ]; then
       log "Downloading $db NCBI RefSeq GFF ($acc)..."
       local zip="$GFF_DIR/$db.ncbi_dataset.zip"
       local extract="$GFF_DIR/$db.ncbi_dataset"

--- a/ucsc2jbrowse/make.sh
+++ b/ucsc2jbrowse/make.sh
@@ -7,7 +7,11 @@
 # Usage:
 #   ./make.sh                  # Download + process (default)
 #   ./make.sh --skip-download  # Skip download, just process
-#   ./make.sh --reprocess-all  # Force reprocess everything
+#   ./make.sh --reprocess-all  # Force reprocess everything from cached downloads
+#
+# --reprocess-all re-derives every config from already-downloaded data; it does
+# not re-pull NCBI RefSeq GFFs (set FETCH_UPDATES=1 for that). The UCSC rsync it
+# still runs is incremental, so an already-synced tree transfers almost nothing.
 #
 
 set -euo pipefail
@@ -32,7 +36,8 @@ for arg in "$@"; do
     echo "Options:"
     echo "  (default)          Download and process all assemblies"
     echo "  --skip-download    Skip download, just process existing data"
-    echo "  --reprocess-all    Force reprocess everything (ignores cached hashes)"
+    echo "  --reprocess-all    Reprocess everything from cached downloads"
+    echo "                     (ignores cached hashes; FETCH_UPDATES=1 re-pulls GFFs)"
     echo "  --help, -h         Show this help message"
     exit 0
     ;;

--- a/ucsc2jbrowse/src/mergeBigFileTracks.ts
+++ b/ucsc2jbrowse/src/mergeBigFileTracks.ts
@@ -1,4 +1,4 @@
-import { dedupe } from 'hubtools'
+import { dedupe, firstField } from 'hubtools'
 
 import { checkIfFileAccessible } from './checkIfFileAccessible.ts'
 import { readConfig, readJSON, splitOnFirst, writeJSON } from './util.ts'
@@ -12,6 +12,8 @@ interface BigDataTrack {
     type?: string
     longLabel?: string
     speciesLabels?: string
+    labelFields?: string
+    defaultLabelFields?: string
   }
 }
 
@@ -158,12 +160,25 @@ async function addBigDataTracks(
               },
             })
           } else {
+            // bigGenePred groups transcripts into genes; UCSC's own
+            // defaultLabelFields (fallback labelFields) names the gene field to
+            // aggregate on, e.g. name2 for ncbiRefSeq, rather than the adapter's
+            // fixed geneName2 default
+            const aggregateField =
+              type === 'bigGenePred'
+                ? (firstField(settings.defaultLabelFields) ??
+                  firstField(settings.labelFields))
+                : undefined
             newTracks.push({
               trackId,
               name: tableName,
               type: 'FeatureTrack',
               assemblyNames: [assemblyName],
-              adapter: { type: 'BigBedAdapter', uri },
+              adapter: {
+                type: 'BigBedAdapter',
+                uri,
+                ...(aggregateField ? { aggregateField } : {}),
+              },
             })
           }
         }


### PR DESCRIPTION
Set BigBedAdapter aggregateField from the trackDb defaultLabelFields (fallback labelFields) for bigGenePred tracks, so transcripts aggregate on the gene field UCSC actually declares (e.g. name2 for ncbiRefSeq) rather than the adapter's fixed geneName2 default. Applied to both the hub path (createTrackConfiguration) and the UCSC golden-path db path (mergeBigFileTracks).

Also align ucsc2jbrowse's NCBI RefSeq GFF fetch with genark2jbrowse: gate re-download on FETCH_UPDATES instead of REPROCESS, so a unified run.sh --reprocess-all re-derives every config from cached downloads without re-pulling GFFs from NCBI.